### PR TITLE
COOK-1420 Correcting name of Template's Cookbook.

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -55,7 +55,8 @@ action :before_migrate do
   end
   if new_resource.requirements
     Chef::Log.info("Installing using requirements file: #{new_resource.requirements}")
-    execute "pip install -E #{new_resource.virtualenv} -r #{new_resource.requirements}" do
+    pip_cmd = ::File.join(new_resource.virtualenv, 'bin', 'pip')
+    execute "#{pip_cmd} install -r #{new_resource.requirements}" do
       cwd new_resource.release_path
     end
   else


### PR DESCRIPTION
Per https://github.com/opscode-cookbooks/application_python/blob/master/providers/django.rb#L117

The default source Cookbook for this Template is set to 'application_django'. I believe this is a misnomer as this Cookbook is (at least now) called 'application_python'.

JIRA: http://tickets.opscode.com/browse/COOK-1420

PLEASEREVIEW: @jtimberman @coderanger @andreacampi
