### PR TITLE
COOK-1420 Correcting name of Template's Cookbook.

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -114,7 +114,7 @@ def created_settings_file
 
   template "#{new_resource.path}/shared/#{new_resource.local_settings_base}" do
     source new_resource.settings_template || "settings.py.erb"
-    cookbook new_resource.settings_template ? new_resource.cookbook_name : "application_django"
+    cookbook new_resource.settings_template ? new_resource.cookbook_name : "application_python"
     owner new_resource.owner
     group new_resource.group
     mode "644"


### PR DESCRIPTION
Per https://github.com/opscode-cookbooks/application_python/blob/master/providers/django.rb#L117

The default source Cookbook for this Template is set to 'application_django'. I believe this is a misnomer as this Cookbook is (at least now) called 'application_python'.

JIRA: http://tickets.opscode.com/browse/COOK-1420

PLEASEREVIEW: @jtimberman @coderanger @andreacampi
