### PR TITLE
COOK-1421 Updated pip to use new virtualenv syntax.

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -55,7 +55,8 @@ action :before_migrate do
   end
   if new_resource.requirements
     Chef::Log.info("Installing using requirements file: #{new_resource.requirements}")
-    execute "pip install -E #{new_resource.virtualenv} -r #{new_resource.requirements}" do
+    pip_cmd = ::File.join(new_resource.virtualenv, 'bin', 'pip')
+    execute "#{pip_cmd} install -r #{new_resource.requirements}" do
       cwd new_resource.release_path
     end
   else


### PR DESCRIPTION
Per https://github.com/opscode-cookbooks/application_python/blob/master/providers/django.rb#L58

pip is using the old -E environments syntax. This option has been removed in favor of calling the pip from the environment itself: http://www.pip-installer.org/en/latest/other-tools.html#using-pip-with-virtualenv

> pip is most nutritious when used with virtualenv. One of the reasons pip doesn't install "multi-version" eggs is that virtualenv removes much of the need for it. Because pip is installed by virtualenv, just use path/to/my/environment/bin/pip to install things into that specific environment.

JIRA: http://tickets.opscode.com/browse/COOK-1421

PLEASEREVIEW: @jtimberman @coderanger @andreacampi
