### PR TITLE
COOK-1422 Removing migrate arg from syncdb.

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -24,7 +24,7 @@ action :before_compile do
 
   include_recipe 'python'
 
-  new_resource.migration_command "#{::File.join(new_resource.virtualenv, "bin", "python")} manage.py syncdb --migrate --noinput" if !new_resource.migration_command
+  new_resource.migration_command "#{::File.join(new_resource.virtualenv, "bin", "python")} manage.py syncdb --noinput" if !new_resource.migration_command
 
   new_resource.symlink_before_migrate.update({
     new_resource.local_settings_base => new_resource.local_settings_file,


### PR DESCRIPTION
Per https://github.com/opscode-cookbooks/application_python/blob/master/providers/django.rb#L27

We're passing the --migrate option to syncdb, which doesn't seem to be supported in Django 1.4 (at least as far as I can find).

JIRA: http://tickets.opscode.com/browse/COOK-1422

PLEASEREVIEW: @jtimberman @coderanger @andreacampi
