### PR TITLE
COOK-1477 Changing install to use non-constant source dir: Dir.tmpdir

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+require 'tmpdir'
+
 include Chef::Mixin::LanguageIncludeRecipe
 
 action :before_compile do
@@ -55,7 +57,7 @@ action :before_migrate do
   end
   if new_resource.requirements
     Chef::Log.info("Installing using requirements file: #{new_resource.requirements}")
-    execute "pip install -E #{new_resource.virtualenv} -r #{new_resource.requirements}" do
+    execute "pip install --source=#{Dir.tmpdir} -E #{new_resource.virtualenv} -r #{new_resource.requirements}" do
       cwd new_resource.release_path
     end
   else


### PR DESCRIPTION
Changing **pip -e** to use a non-constant src dir: `Dir.tmpdir`

JIRA: [COOK-1477 pip's requirements.txt and "Editable Package" support in application_python](http://tickets.opscode.com/browse/COOK-1477)

PLEASEREVIEW: @jtimberman
