### PR TITLE
Correctly detect if celerybeat should be added as a command

### DIFF
--- a/providers/celery.rb
+++ b/providers/celery.rb
@@ -62,7 +62,7 @@ action :before_deploy do
 
   cmds = {}
   cmds[:celeryd] = "celeryd #{new_resource.celerycam ? "-E" : ""}" if new_resource.celeryd
-  cmds[:celerybeat] = "celerybeat" if new_resource.celerycam
+  cmds[:celerybeat] = "celerybeat" if new_resource.celerybeat
   if new_resource.celerycam
     if new_resource.django
       cmd = "celerycam"


### PR DESCRIPTION
Previously, you couldn't have a box running celerybeat and not celerycam.
