### PR TITLE
Update for non-ancient pip

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -122,7 +122,7 @@ def created_settings_file
     group new_resource.group
     mode "644"
     variables new_resource.settings.clone
-    variables.update :debug => new_resource.debug, :database => {
+    variables.update :django => new_resource, :debug => new_resource.debug, :database => {
       :host => host,
       :settings => new_resource.database,
       :legacy => new_resource.legacy_database_settings


### PR DESCRIPTION
-E argument is long since gone.
