### PR TITLE
COOK-2330: use String#upcase in celeryconfig.py.erb

### DIFF
--- a/templates/default/celeryconfig.py.erb
+++ b/templates/default/celeryconfig.py.erb
@@ -2,12 +2,12 @@ BROKER_TRANSPORT = "<%= @broker[:transport] %>"
 BROKER_HOST = "<%= @broker[:host] %>"
 <% %w{port user password vhost}.each do |key| %>
 <% if @broker[key] %>
-BROKER_<%= key.upper %> = "<%= @broker[key] %>"
+BROKER_<%= key.upcase %> = "<%= @broker[key] %>"
 <% end %>
 <% end %>
 <% %w{pool_limit connection_timeout connection_retry connection_max_retries}.each do |key| %>
 <% if @broker[key] %>
-BROKER_<%= key.upper %> = <%= @broker[key] %>
+BROKER_<%= key.upcase %> = <%= @broker[key] %>
 <% end %>
 <% end %>
 <% if @broker[:use_ssl] %>


### PR DESCRIPTION
I'm not sure how (or if) this ever worked before, as String#upper doesn't seem to be a valid method.
