### PR TITLE
[COOK-2403] Cast symbol to string in templates

### DIFF
--- a/providers/celery.rb
+++ b/providers/celery.rb
@@ -53,7 +53,7 @@ action :before_deploy do
 
   template ::File.join(new_resource.application.path, "shared", new_resource.config_base) do
     source new_resource.template || "celeryconfig.py.erb"
-    cookbook new_resource.template ? new_resource.cookbook_name : "application_python"
+    cookbook new_resource.template ? new_resource.cookbook_name.to_s : "application_python"
     owner new_resource.owner
     group new_resource.group
     mode "644"

--- a/providers/gunicorn.rb
+++ b/providers/gunicorn.rb
@@ -50,7 +50,7 @@ action :before_deploy do
   gunicorn_config "#{new_resource.application.path}/shared/gunicorn_config.py" do
     action :create
     template new_resource.settings_template || 'gunicorn.py.erb'
-    cookbook new_resource.settings_template ? new_resource.cookbook_name : 'gunicorn'
+    cookbook new_resource.settings_template ? new_resource.cookbook_name.to_s : 'gunicorn'
     listen "#{new_resource.host}:#{new_resource.port}"
     backlog new_resource.backlog
     worker_processes new_resource.workers


### PR DESCRIPTION
Cast the cookbook_name symbol to a string, so that the gunicorn_config
and template resources being created work if a custom template is
provided.
