### PR TITLE
Add a directory parameter to control gunicorn working directory

### DIFF
--- a/providers/gunicorn.rb
+++ b/providers/gunicorn.rb
@@ -84,7 +84,7 @@ action :before_deploy do
       base_command = "#{gunicorn_command} #{new_resource.app_module}"
     end
     command "#{base_command} -c #{new_resource.application.path}/shared/gunicorn_config.py"
-    directory ::File.join(new_resource.path, "current")
+    directory new_resource.directory.nil? ? ::File.join(new_resource.path, "current") : new_resource.directory
     autostart false
     user new_resource.owner
   end

--- a/resources/gunicorn.rb
+++ b/resources/gunicorn.rb
@@ -45,3 +45,4 @@ attribute :virtualenv, :kind_of => String, :default => nil
 attribute :packages, :kind_of => [Array, Hash], :default => []
 attribute :requirements, :kind_of => [NilClass, String, FalseClass], :default => nil
 attribute :environment, :kind_of => [Hash], :default => {}
+attribute :directory, :kind_of => [NilClass, String], :default => nil


### PR DESCRIPTION
In some scenarios it is important that gunicorn be executed from a path other than the current release directory. This change adds a 'directory' attribute to the gunicorn submodule. When set, the value of this attribute is used to configure gunicorn's working directory.
