### PR TITLE
[COOK-2599] gunicorn provider fails if no node['cpu']['total']

### DIFF
--- a/resources/gunicorn.rb
+++ b/resources/gunicorn.rb
@@ -26,7 +26,7 @@ attribute :settings_template, :kind_of => [String, NilClass], :default => nil
 attribute :host, :kind_of => String, :default => '0.0.0.0'
 attribute :port, :kind_of => Integer, :default => 8080
 attribute :backlog, :kind_of => Integer, :default => 2048
-attribute :workers, :kind_of => Integer, :default => [node['cpu']['total'].to_i * 4, 8].min
+attribute :workers, :kind_of => Integer, :default => (node['cpu'] && node['cpu']['total']) && [node['cpu']['total'].to_i * 4, 8].min || 8
 attribute :worker_class, :kind_of => [String, Symbol], :default => :sync
 attribute :worker_connections, :kind_of => Integer, :default => 1000
 attribute :max_requests, :kind_of => Integer, :default => 0


### PR DESCRIPTION
ohai does not populate node['cpu'] on SmartOS today.
To prevent this blocking use of application_python I suggest
this workaround.
