### PR TITLE
COOK-2766: use deployment key when installing reqs with pip

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -62,7 +62,13 @@ action :before_migrate do
       cwd new_resource.release_path
       # seems that if we don't set the HOME env var pip tries to log to /root/.pip, which fails due to permissions
       # setting HOME also enables us to control pip behavior on per-project basis by dropping off a pip.conf file there
-      environment 'HOME' => ::File.join(new_resource.path,'shared')
+      # GIT_SSH allow us to reuse the deployment key used to clone the main
+      # repository to clone any private requirements
+      if new_resource.deploy_key
+        environment 'HOME' => ::File.join(new_resource.path,'shared'), 'GIT_SSH' => "#{new_resource.path}/deploy-ssh-wrapper"
+      else
+        environment 'HOME' => ::File.join(new_resource.path,'shared')
+      end
       user new_resource.owner
       group new_resource.group
     end


### PR DESCRIPTION
this uses the deployment key from the "main" application ressource (if given) also when installing the requirements.txt
