### PR TITLE
[COOK-3738] Expose the raw resource to the settings template

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -137,7 +137,7 @@ def created_settings_file
     group new_resource.group
     mode "644"
     variables new_resource.settings.clone
-    variables.update :debug => new_resource.debug, :database => {
+    variables.update :django => new_resource, :debug => new_resource.debug, :database => {
       :host => host,
       :settings => new_resource.database,
       :legacy => new_resource.legacy_database_settings


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3738

This allows stuff like `<%= @django.application.path %>` in settings.
