### PR TITLE
Make celery LWRP honor virtualenv and CELERY_CONFIG_MODULE

### DIFF
--- a/providers/celery.rb
+++ b/providers/celery.rb
@@ -94,11 +94,15 @@ action :before_deploy do
         command "#{::File.join(django_resource.virtualenv, "bin", "python")} manage.py #{cmd}"
         environment new_resource.environment
       else
-        command cmd
-        if new_resource.environment
-          environment new_resource.environment.merge({'CELERY_CONFIG_MODULE' => new_resource.config})
+        if new_resource.virtualenv
+          command "#{::File.join(new_resource.virtualenv, "bin", cmd)}"
         else
-          environment 'CELERY_CONFIG_MODULE' => new_resource.config
+          command cmd
+        end
+        if new_resource.environment
+          environment new_resource.environment.merge({'CELERY_CONFIG_MODULE' => new_resource.config_module})
+        else
+          environment 'CELERY_CONFIG_MODULE' => new_resource.config_module
         end
       end
       directory ::File.join(new_resource.path, "current")

--- a/resources/celery.rb
+++ b/resources/celery.rb
@@ -30,9 +30,21 @@ attribute :camera_class, :kind_of => [String, NilClass], :default => nil
 attribute :enable_events, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :environment, :kind_of => [Hash], :default => {}
 attribute :queues, :kind_of => [Array,NilClass], :default => nil
+attribute :virtualenv, :kind_of => [String, NilClass], :default => nil
 
 def config_base
   config.split(/[\\\/]/).last
+end
+
+def config_module
+  # CELERY_CONFIG_MODULE expects a python
+  # module name, not a file path, but we
+  # need a filename for the config option
+  # to set up symlinks and what-not. This
+  # function gives the first part of the
+  # filename so that we can use it for the
+  # module name.
+  config.split(/\./).first
 end
 
 def broker(*args, &block)


### PR DESCRIPTION
The virtualenv is necessary to make sure that we are enabling the proper version of celery. 

Additionally, the way the non-django path of the code was working would not properly load the CELERY_CONFIG_MODULE due to the fact that celery expects a python module name, but was getting a filename (e.g. celery_settings vs. celery_settings.py).