### PR TITLE
[COOK-3418] Don't store non temporary files in /tmp

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -58,7 +58,7 @@ action :before_migrate do
   if new_resource.requirements
     Chef::Log.info("Installing using requirements file: #{new_resource.requirements}")
     pip_cmd = ::File.join(new_resource.virtualenv, 'bin', 'pip')
-    execute "#{pip_cmd} install --source=#{Dir.tmpdir} -r #{new_resource.requirements}" do
+    execute "#{pip_cmd} install --exists-action w -r #{new_resource.requirements}" do
       cwd new_resource.release_path
       # seems that if we don't set the HOME env var pip tries to log to /root/.pip, which fails due to permissions
       # setting HOME also enables us to control pip behavior on per-project basis by dropping off a pip.conf file there

--- a/providers/gunicorn.rb
+++ b/providers/gunicorn.rb
@@ -137,7 +137,7 @@ def install_requirements
     else
       pip_cmd = ::File.join(new_resource.virtualenv, 'bin', 'pip')
     end
-    execute "#{pip_cmd} install --src=#{Dir.tmpdir} -r #{new_resource.requirements}" do
+    execute "#{pip_cmd} install --exists-action w -r #{new_resource.requirements}" do
       cwd new_resource.release_path
     end
   else


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3418

* Actually fixes COOK-1447
* Doesn't store non temporary files inside of /tmp