### PR TITLE
[COOK-3432] Chef::Mixin::LanguageIncludeRecipe is deprecated, use Chef::DSL::IncludeRecipe instead.

### DIFF
--- a/providers/celery.rb
+++ b/providers/celery.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 

--- a/providers/django.rb
+++ b/providers/django.rb
@@ -20,7 +20,7 @@
 
 require 'tmpdir'
 
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 

--- a/providers/gunicorn.rb
+++ b/providers/gunicorn.rb
@@ -20,7 +20,7 @@
 
 require 'tmpdir'
 
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3432
