### PR TITLE
[COOK-3645] check for Chef::Version and include the Chef::Mixin::LanguageIncludeRecipe for older versions.

### DIFF
--- a/providers/celery.rb
+++ b/providers/celery.rb
@@ -18,7 +18,11 @@
 # limitations under the License.
 #
 
-include Chef::DSL::IncludeRecipe
+if Chef::Version.new(Chef::VERSION) < Chef::Version.new("11.0.0")
+  include Chef::Mixin::LanguageIncludeRecipe
+else
+  include Chef::DSL::IncludeRecipe
+end
 
 action :before_compile do
 

--- a/providers/django.rb
+++ b/providers/django.rb
@@ -20,7 +20,11 @@
 
 require 'tmpdir'
 
-include Chef::DSL::IncludeRecipe
+if Chef::Version.new(Chef::VERSION) < Chef::Version.new("11.0.0")
+  include Chef::Mixin::LanguageIncludeRecipe
+else
+  include Chef::DSL::IncludeRecipe
+end
 
 action :before_compile do
 

--- a/providers/gunicorn.rb
+++ b/providers/gunicorn.rb
@@ -20,7 +20,11 @@
 
 require 'tmpdir'
 
-include Chef::DSL::IncludeRecipe
+if Chef::Version.new(Chef::VERSION) < Chef::Version.new("11.0.0")
+  include Chef::Mixin::LanguageIncludeRecipe
+else
+  include Chef::DSL::IncludeRecipe
+end
 
 action :before_compile do
 


### PR DESCRIPTION
Restores compatibility with 10.x, broken in COOK-3432.
