### PR TITLE
Allow setting --allow-external and --allow-unverified

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ A new virtualenv will be created for the application in "#{path}/shared/env"; pi
 - legacy_database_settings: if true, the default settings template will generate legacy database config variables. Defaults to false
 - debug: used by the default settings template to control debugging. Defaults to false
 - collectstatic: controls the behavior of the `staticfiles` app. If true, if will invoke manage.py with `collectstatic --noinput`; you can also pass a String with an explicit command (see Usage below). Defaults to false
+- allow_external: an array of pip packages that are allowed to be fetched from external sources.
+- allow_unverified: an array of pip packages that are allowed to be installed without checking a checksum from a verified source.
 
 #### Database block parameters
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Deploys and configures Python-based applications"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.0.1"
+version          "3.0.2"
 
 %w{ python gunicorn supervisor }.each do |cb|
   depends cb

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Deploys and configures Python-based applications"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.0.2"
+version          "3.0.3"
 
 %w{ python gunicorn supervisor }.each do |cb|
   depends cb

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,4 +10,4 @@ version          "3.0.3"
   depends cb
 end
 
-depends "application", "~> 3.0"
+depends "application"

--- a/providers/django.rb
+++ b/providers/django.rb
@@ -58,7 +58,10 @@ action :before_migrate do
   if new_resource.requirements
     Chef::Log.info("Installing using requirements file: #{new_resource.requirements}")
     pip_cmd = ::File.join(new_resource.virtualenv, 'bin', 'pip')
-    execute "#{pip_cmd} install --source=#{Dir.tmpdir} -r #{new_resource.requirements}" do
+    pip_cmd << " install --source=#{Dir.tmpdir} -r #{new_resource.requirements}"
+    pip_cmd << new_resource.allow_external.map { |x| " --allow-external #{x}" }.join('')
+    pip_cmd << new_resource.allow_unverified.map { |x| " --allow-unverified #{x}" }.join('')
+    execute pip_cmd do
       cwd new_resource.release_path
       # seems that if we don't set the HOME env var pip tries to log to /root/.pip, which fails due to permissions
       # setting HOME also enables us to control pip behavior on per-project basis by dropping off a pip.conf file there

--- a/resources/django.rb
+++ b/resources/django.rb
@@ -22,6 +22,8 @@ include ApplicationCookbook::ResourceBase
 
 attribute :database_master_role, :kind_of => [String, NilClass], :default => nil
 attribute :packages, :kind_of => [Array, Hash], :default => []
+attribute :allow_external, :kind_of => Array, :default => []
+attribute :allow_unverified, :kind_of => Array, :default => []
 attribute :requirements, :kind_of => [NilClass, String, FalseClass], :default => nil
 attribute :legacy_database_settings, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :settings, :kind_of => Hash, :default => {}


### PR DESCRIPTION
With pip 1.5 you need to explicitly allow external sources for certain pip packages. This pull request allows you to set `allow_external` and `allow_unverified` as arrays in the `django` block.