### PR TITLE
run collectstatic in before_restart block with environment variables

### DIFF
--- a/providers/django.rb
+++ b/providers/django.rb
@@ -79,6 +79,9 @@ action :before_migrate do
 end
 
 action :before_symlink do
+end
+
+action :before_restart do
 
   if new_resource.collectstatic
     cmd = new_resource.collectstatic.is_a?(String) ? new_resource.collectstatic : "collectstatic --noinput"
@@ -86,6 +89,7 @@ action :before_symlink do
       user new_resource.owner
       group new_resource.group
       cwd new_resource.release_path
+      environment new_resource.environment
     end
   end
 
@@ -98,9 +102,6 @@ action :before_symlink do
     end
   end
 
-end
-
-action :before_restart do
 end
 
 action :after_restart do


### PR DESCRIPTION
move collectstatic into before_restart as it might depend on symlinked in settings and run with the appropriate environment variables