### PR TITLE
Unlock application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-application_python Cookbook
-===========================
+application_python Cookbook (Needle-Cookbooks Fork)
+===================================================
+This our own fork of the application_python cookbook. We forked it to allow us to change the numprocs and process_name settings for the haystack-celeryd supervisor config.
+
 This cookbook is designed to be able to describe and deploy Python web applications. Currently supported:
 
 - plain python web applications

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Deploys and configures Python-based applications"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.0.1"
+version          "16.0.0"
 
 %w{ python gunicorn supervisor }.each do |cb|
   depends cb

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,10 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Deploys and configures Python-based applications"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "16.0.0"
+version          "16.1.0"
 
 %w{ python gunicorn supervisor }.each do |cb|
   depends cb
 end
 
-depends "application", "~> 3.0"
+depends "application"

--- a/providers/celery.rb
+++ b/providers/celery.rb
@@ -102,6 +102,12 @@ action :before_deploy do
           environment 'CELERY_CONFIG_MODULE' => new_resource.config
         end
       end
+      ## We added this block to allow us to alter the default process_name and numprocs for
+      ## haystack-celerd. This is the reason we are forking this cookbook.
+      if "#{new_resource.application.name}-#{type}".eql?("haystack-celeryd")
+        process_name '%(program_name)s_%(process_num)02d'
+        numprocs 6
+      end
       directory ::File.join(new_resource.path, "current")
       autostart false
       user new_resource.owner

--- a/resources/celery.rb
+++ b/resources/celery.rb
@@ -30,6 +30,9 @@ attribute :camera_class, :kind_of => [String, NilClass], :default => nil
 attribute :enable_events, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :environment, :kind_of => [Hash], :default => {}
 attribute :queues, :kind_of => [Array,NilClass], :default => nil
+## Added process_name and numprocs for haystack-celeryd override in providers/celeryd
+attribute :process_name, :kind_of => [String, NilClass], :default => '%(program_name)s'
+attribute :numprocs, :kind_of => Integer, :default => 1
 
 def config_base
   config.split(/[\\\/]/).last


### PR DESCRIPTION
Bumped version and unlocked application to use Chef 12 fix in Application 4.1.6

Without this, we will get application errors when we try to run this with Chef 12.