### PR TITLE
dont write local_settings.py if i dont specify params

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,4 +10,4 @@ version          "3.0.1"
   depends cb
 end
 
-depends "application", "~> 3.0"
+depends "application", "= 4.1.6"

--- a/providers/django.rb
+++ b/providers/django.rb
@@ -29,8 +29,8 @@ action :before_compile do
   new_resource.migration_command "#{::File.join(new_resource.virtualenv, "bin", "python")} manage.py syncdb --noinput" if !new_resource.migration_command
 
   new_resource.symlink_before_migrate.update({
-    new_resource.local_settings_base => new_resource.local_settings_file,
-  })
+                                               new_resource.local_settings_base => new_resource.local_settings_file,
+                                             })
 end
 
 action :before_deploy do
@@ -130,17 +130,19 @@ end
 def created_settings_file
   host = new_resource.find_database_server(new_resource.database_master_role)
 
-  template "#{new_resource.path}/shared/#{new_resource.local_settings_base}" do
-    source new_resource.settings_template || "settings.py.erb"
-    cookbook new_resource.settings_template ? new_resource.cookbook_name.to_s : "application_python"
-    owner new_resource.owner
-    group new_resource.group
-    mode "644"
-    variables new_resource.settings.clone
-    variables.update :django => new_resource, :debug => new_resource.debug, :database => {
-      :host => host,
-      :settings => new_resource.database,
-      :legacy => new_resource.legacy_database_settings
-    }
+  unless new_resource.database
+    template "#{new_resource.path}/shared/#{new_resource.local_settings_base}" do
+      source new_resource.settings_template || "settings.py.erb"
+      cookbook new_resource.settings_template ? new_resource.cookbook_name.to_s : "application_python"
+      owner new_resource.owner
+      group new_resource.group
+      mode "644"
+      variables new_resource.settings.clone
+      variables.update :django => new_resource, :debug => new_resource.debug, :database => {
+                         :host => host,
+                         :settings => new_resource.database,
+                         :legacy => new_resource.legacy_database_settings
+                       }
+    end
   end
 end


### PR DESCRIPTION
calling `created_settings_file` every run doesn't do what I want, I don't want to have the provider search for the right database server, i just want to plop my own local_settings.py in place, and this simple fix (Line133) should do it.