### PR TITLE
allow the user to pass worker_pool to the celery_worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ end
 
 * `path` – Base path for the application. *(name attribute)*
 * `app_module` – Celery application module. *(default: auto-detect)*
+* `worker_pool` – The Pool implementation used by the Celery worker (gevent,eventlet or prefork). *(default: prefork)*
 * `service_name` – Name of the service to create. *(default: auto-detect)*
 # `user` – User to run the service as. *(default: application owner)*
 

--- a/lib/poise_application_python/resources/celery_worker.rb
+++ b/lib/poise_application_python/resources/celery_worker.rb
@@ -29,6 +29,7 @@ module PoiseApplicationPython
         include PoiseApplicationPython::ServiceMixin
         provides(:application_celery_worker)
 
+        attribute(:worker_pool, kind_of: [String, NilClass], default: "prefork")
         attribute(:app_module, kind_of: [String, NilClass], default: lazy { default_app_module })
 
         private
@@ -68,7 +69,7 @@ module PoiseApplicationPython
         def service_options(resource)
           super
           raise PoiseApplicationPython::Error.new("Unable to determine app module for #{new_resource}") unless new_resource.app_module
-          resource.command("#{new_resource.python} -m celery --app=#{new_resource.app_module} worker")
+          resource.command("#{new_resource.python} -m celery --app=#{new_resource.app_module} -P #{new_resource.worker_pool} worker")
         end
 
       end


### PR DESCRIPTION
worker_pool can not be set in the celery configuration and it
needs to be set via -P option while starting the worker i added it
to the celery_worker.rb
ref: http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-worker_pool